### PR TITLE
Fix ESLint Error

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,13 +2,14 @@
   "env": {
     "browser": true,
     "node": true,
-    "es2021": true,
-    "no-unused-vars": "off"
+    "es2021": true
   },
   "extends": "eslint:recommended",
   "parserOptions": {
     "ecmaVersion": "latest",
     "sourceType": "module"
   },
-  "rules": {}
+  "rules": {
+    "no-unused-vars": "off"
+  }
 }


### PR DESCRIPTION
There is an error about "no-unused-vars" being an invalid environment key.

Let's move "no-unused-vars" into the rules section.