### PR TITLE
Add pre-commit hook to detect secrets

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.16.1
+    hooks:
+      - id: gitleaks
+        stages: [commit]

--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ your services / frontend.
 
 ### Getting Started - Local Development:
 
+1. **Installing secret detection hooks:** From the root directory, run:
+    ```bash
+    pip install pre-commit
+    pre-commit install
+    ```
+   
+**Disclaimer:** There is no guarantee that all secrets will be detected.
+As a tip, if you think a file will eventually store secrets, immediately add it to .gitignore upon creating
+it in case you forget later on when you have a lot more files to commit.
+
+
 1. **Installing Dependencies:** From the root directory (`/peerprep`), run:
 
    ```bash


### PR DESCRIPTION
Detecting a secret before it is committed is preferable to revoking
and replacing the secret should it be accidentally committed.

Let's add support for a secret detection pre-commit hook to serve
as an additional safety net.