### PR TITLE
Docker hot reload

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
       context: .
       dockerfile: deployment/dev-dockerfiles/Dockerfile.user-service
     container_name: user-service
+    volumes:
+      - ./services/user-service:/app/services/user-service
     ports:
       - "5001:5001"
     environment:
@@ -17,6 +19,8 @@ services:
       context: .
       dockerfile: deployment/dev-dockerfiles/Dockerfile.matching-service
     container_name: matching-service
+    volumes:
+      - ./services/matching-service:/app/services/matching-service
     ports:
       - "5002:5002"
     environment:
@@ -28,6 +32,9 @@ services:
       context: .
       dockerfile: deployment/dev-dockerfiles/Dockerfile.collaboration-service
     container_name: collaboration-service
+    volumes:
+      - ./services/collaboration-service:/app/services/collaboration-service
+      - ./utils:/app/utils
     ports:
       - "5003:5003"
     environment:
@@ -39,6 +46,8 @@ services:
       context: .
       dockerfile: deployment/dev-dockerfiles/Dockerfile.question-service
     container_name: question-service
+    volumes:
+      - ./services/question-service:/app/services/question-service
     ports:
       - "5004:5004"
     environment:
@@ -50,6 +59,8 @@ services:
       context: .
       dockerfile: deployment/dev-dockerfiles/Dockerfile.admin-service
     container_name: admin-service
+    volumes:
+      - ./services/admin-service:/app/services/admin-service
     ports:
       - "5005:5005"
     environment:
@@ -61,6 +72,8 @@ services:
       context: .
       dockerfile: deployment/dev-dockerfiles/Dockerfile.gateway
     container_name: gateway
+    volumes:
+      - ./services/gateway:/app/services/gateway
     ports:
       - "4000:4000"
     environment:
@@ -72,6 +85,9 @@ services:
       context: .
       dockerfile: deployment/dev-dockerfiles/Dockerfile.frontend
     container_name: frontend
+    volumes:
+      - ./frontend:/app/frontend
+      - ./utils:/app/utils
     ports:
       - "3000:3000"
     environment:

--- a/services/gateway/src/auth/firebase.ts
+++ b/services/gateway/src/auth/firebase.ts
@@ -5,8 +5,8 @@ import process from "process";
 import dotenv from "dotenv";
 import { App } from "firebase-admin/lib/app";
 
-const serviceAccount = process.env.NEXT_PUBLIC_FRONTEND_FIREBASE_CONFIG
-  ? JSON.parse(process.env.NEXT_PUBLIC_FRONTEND_FIREBASE_CONFIG as string)
+const serviceAccount = process.env.FIREBASE_SERVICE_ACCOUNT
+  ? JSON.parse(process.env.FIREBASE_SERVICE_ACCOUNT as string)
   : {};
 
 const firebaseApp: App = admin.initializeApp({


### PR DESCRIPTION
Allow hot reload by mounting volumes.

Also fix issue with gateway env variable (gateway is not run on frontend, so we don't use `NEXT_PUBLIC_FRONTEND_FIREBASE_CONFIG`)