### PR TITLE
Change status code for POST with user already in database

### DIFF
--- a/services/user-service/src/routes/index.ts
+++ b/services/user-service/src/routes/index.ts
@@ -8,7 +8,7 @@ indexRouter.post("/", function (req: express.Request, res: express.Response) {
     .createUser(req.body)
     .then((result) => {
       if (result === null) {
-        res.status(400).append("Is-User-Already-Found", "true").end();
+        res.status(200).append("Is-User-Already-Found", "true").end();
       } else {
         res.status(201).json(result);
       }

--- a/services/user-service/systemtest/app.test.ts
+++ b/services/user-service/systemtest/app.test.ts
@@ -14,7 +14,7 @@ const updatePayload = { matchDifficulty: 1 };
 
 describe('/index', () => {
   describe('Sample App Workflow', () => {
-    it('Step 1: Add user 1 to database should pass', async () => {
+    it('Step 1: Add user 1 to database should pass with status 201', async () => {
       // The function being tested
       const response = await request(app).post('/api/user-service').send(fullNewUser);
       expect(response.status).toStrictEqual(201);
@@ -42,9 +42,9 @@ describe('/index', () => {
       expect(response.body).toStrictEqual(updatedNewUser);
     })
 
-    it('Step 5: Attempt to add duplicate user 1 to database should fail with error', async () => {
+    it('Step 5: Attempt to add duplicate user 1 to database should give status 200', async () => {
       const response = await request(app).post('/api/user-service').send(fullNewUser);
-      expect(response.status).toStrictEqual(400);
+      expect(response.status).toStrictEqual(200);
     })
 
     it('Step 6: Delete user 1 from database', async () => {

--- a/services/user-service/test/routes/index.test.ts
+++ b/services/user-service/test/routes/index.test.ts
@@ -42,7 +42,7 @@ describe('/index', () => {
 
       // The function being tested
       const response = await request(app).post('/').send(fullNewUser);
-      expect(response.status).toStrictEqual(400);
+      expect(response.status).toStrictEqual(200);
     })
 
     it('[POST] to / when database is unavailable', async () => {


### PR DESCRIPTION
Commit message:
```
The 400 error when POSTing to the database when the user is already
inside can surprise developers during debugging because everytime a
user logs in, the POST is made regardless of whether the user is inside
the database or not.

Let's change the status code to 200 to avoid showing it as an error
while still differentiating it from the status code 201 when the user
details are added for the first time.

```