### PR TITLE
Fix admin verification

### DIFF
--- a/services/gateway/src/auth/firebase.ts
+++ b/services/gateway/src/auth/firebase.ts
@@ -42,6 +42,7 @@ export function promiseVerifyIsAdmin(idToken: string) {
   return firebaseAuth
     .verifyIdToken(idToken, true)
     .then((claims) => {
+      console.log(claims)
       return !!claims.admin;
     })
     .catch((error) => {

--- a/services/gateway/src/auth/firebase.ts
+++ b/services/gateway/src/auth/firebase.ts
@@ -42,7 +42,6 @@ export function promiseVerifyIsAdmin(idToken: string) {
   return firebaseAuth
     .verifyIdToken(idToken, true)
     .then((claims) => {
-      console.log(claims)
       return !!claims.admin;
     })
     .catch((error) => {

--- a/services/gateway/src/proxied_routes/proxied_routes.ts
+++ b/services/gateway/src/proxied_routes/proxied_routes.ts
@@ -24,19 +24,16 @@ export const proxied_routes: ProxiedRoute[] = [
   },
   {
     url: "/api/admin-service",
-    admin_required_methods: ["GET, POST, PUT, DELETE"], // All routes in admin service can only be accessed by admins
+    admin_required_methods: ["GET", "POST", "PUT", "DELETE"], // All routes in admin service can only be accessed by admins
     user_match_required_methods: [], // No need for exact user match here
     proxy: {
       target: adminServiceAddress,
       changeOrigin: true,
-      pathRewrite: {
-        "^/api/admin-service": "",
-      },
     },
   },
   {
     url: "/api/question-service",
-    admin_required_methods: ["POST, PUT, DELETE"], // Only admins can create, update or delete questions
+    admin_required_methods: ["POST", "PUT", "DELETE"], // Only admins can create, update or delete questions
     user_match_required_methods: [], // No need for exact user match here
     proxy: {
       target: questionServiceAddress,
@@ -58,15 +55,6 @@ export const proxied_routes: ProxiedRoute[] = [
     user_match_required_methods: [], // No need for exact user match here
     proxy: {
       target: collaborationServiceAddress,
-      changeOrigin: true,
-    },
-  },
-  {
-    url: "/api/question-service",
-    admin_required_methods: ["POST, PUT, DELETE"], // All routes in admin service can only be accessed by admins
-    user_match_required_methods: [], // No need for exact user match here
-    proxy: {
-      target: questionServiceAddress,
       changeOrigin: true,
     },
   },


### PR DESCRIPTION
Fixes #143 

Admin verification does not work because app.get(), app.post() etc are
used to apply the verification as middleware even though this is not
the correct way to do so.

Let's switch to app.use and decide whether to do the verification in 
the middleware using the req.method property.