### PR TITLE
Fix duplicate sockets and display name in video

### DIFF
--- a/frontend/src/hooks/useCollaboration.tsx
+++ b/frontend/src/hooks/useCollaboration.tsx
@@ -77,7 +77,10 @@ const useCollaboration = ({
             "User-Id-Token": token,
           },
         });
-        setSocket(socketConnection);
+        setSocket((prevSocket) => {
+          prevSocket?.disconnect();
+          return socketConnection;
+        });
 
         socketConnection.emit(SocketEvents.ROOM_JOIN, roomId, userId);
         if (
@@ -123,11 +126,11 @@ const useCollaboration = ({
             cursor: number | undefined | null;
           }) => {
             prevCursorRef.current = cursorRef.current;
-            console.log("prevCursor: " + prevCursorRef.current);
+            // console.log("prevCursor: " + prevCursorRef.current);
 
-            console.log("cursor: " + cursor);
+            // console.log("cursor: " + cursor);
 
-            console.log("Update vers to " + version);
+            // console.log("Update vers to " + version);
             vers = version;
 
             if (awaitingAck.current) return;
@@ -136,13 +139,13 @@ const useCollaboration = ({
             prevTextRef.current = text;
             setText(text);
             if (cursor && cursor > -1) {
-              console.log("Update cursor to " + cursor);
+              // console.log("Update cursor to " + cursor);
               cursorRef.current = cursor;
               setCursor(cursor);
             } else {
               cursorRef.current = prevCursorRef.current;
               cursor = prevCursorRef.current;
-              console.log("Update cursor to " + prevCursorRef.current);
+              // console.log("Update cursor to " + prevCursorRef.current);
               setCursor(prevCursorRef.current);
             }
             awaitingSync.current = false;
@@ -177,9 +180,9 @@ const useCollaboration = ({
 
     awaitingAck.current = true;
 
-    console.log("prevtext: " + prevTextRef.current);
-    console.log("currenttext: " + textRef.current);
-    console.log("version: " + vers);
+    // console.log("prevtext: " + prevTextRef.current);
+    // console.log("currenttext: " + textRef.current);
+    // console.log("version: " + vers);
     const textOp: TextOp = createTextOpFromTexts(
       prevTextRef.current,
       textRef.current
@@ -187,7 +190,7 @@ const useCollaboration = ({
 
     prevTextRef.current = textRef.current;
 
-    console.log(textOp);
+    // console.log(textOp);
 
     const textOperationSet: TextOperationSetWithCursor = {
       version: vers,

--- a/frontend/src/pages/room/[id].tsx
+++ b/frontend/src/pages/room/[id].tsx
@@ -52,20 +52,27 @@ export default function Room() {
       const questionId = match.questionId;
       setQuestionId(questionId);
       fetchQuestion(questionId).then((fetchQuestion) => {
-        if (fetchQuestion != null) {
+        if (fetchQuestion) {
           setQuestion(fetchQuestion);
         }
       });
     }
 
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+
     if (!match) {
       // leave room and redirect to interviews page
-      leaveMatch();
-      toast.info("Other user has left");
-      router.push("/interviews");
+      timeout = setTimeout(() => {
+        leaveMatch();
+        toast.info("Other user has left");
+        router.push("/interviews");
+      }, 5000);
     }
 
     setLoading(false);
+    return () => {
+      if (timeout) clearTimeout(timeout);
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [match, questionId]);
 

--- a/frontend/src/providers/MatchmakingProvider.tsx
+++ b/frontend/src/providers/MatchmakingProvider.tsx
@@ -21,7 +21,7 @@ interface RequestToChangeQuestion {
 
 interface MatchmakingContextValue {
   socket: Socket | null;
-  match: Match | null;
+  match?: Match | null;
   message: string;
   error: string;
   joinQueue: (difficulties: string[], programmingLang: string) => void;
@@ -45,7 +45,8 @@ export const MatchmakingProvider: React.FC<MatchmakingProviderProps> = ({
   children,
 }) => {
   const [socket, setSocket] = useState<Socket | null>(null);
-  const [match, setMatch] = useState<Match | null>(null);
+  // undefined if is loading, null if not in a match, otherwise Match
+  const [match, setMatch] = useState<Match | null | undefined>(undefined);
   const [message, setMessage] = useState<string>("");
   const [error, setError] = useState<string>("");
   const [requestToChangeQuestion, setRequestToChangeQuestion] = useState<RequestToChangeQuestion | null>(null);
@@ -82,6 +83,7 @@ export const MatchmakingProvider: React.FC<MatchmakingProviderProps> = ({
       });
     }
     return () => {
+      console.log("Socket disconnected");
       socket?.close();
     };
   }, [currentUser]);
@@ -94,7 +96,8 @@ export const MatchmakingProvider: React.FC<MatchmakingProviderProps> = ({
     if (
       match &&
       router.route !== "/interviews/match-found" &&
-      router.route !== "/interviews/find-match"
+      router.route !== "/interviews/find-match" &&
+      router.route !== "/room/${match?.roomId}"
     ) {
       router.push(`/room/${match?.roomId}`);
     }

--- a/frontend/src/providers/MatchmakingProvider.tsx
+++ b/frontend/src/providers/MatchmakingProvider.tsx
@@ -21,7 +21,7 @@ interface RequestToChangeQuestion {
 
 interface MatchmakingContextValue {
   socket: Socket | null;
-  match?: Match | null;
+  match: Match | null;
   message: string;
   error: string;
   joinQueue: (difficulties: string[], programmingLang: string) => void;
@@ -46,7 +46,7 @@ export const MatchmakingProvider: React.FC<MatchmakingProviderProps> = ({
 }) => {
   const [socket, setSocket] = useState<Socket | null>(null);
   // undefined if is loading, null if not in a match, otherwise Match
-  const [match, setMatch] = useState<Match | null | undefined>(undefined);
+  const [match, setMatch] = useState<Match | null>(null);
   const [message, setMessage] = useState<string>("");
   const [error, setError] = useState<string>("");
   const [requestToChangeQuestion, setRequestToChangeQuestion] = useState<RequestToChangeQuestion | null>(null);

--- a/services/collaboration-service/src/db/prisma-db.ts
+++ b/services/collaboration-service/src/db/prisma-db.ts
@@ -161,18 +161,18 @@ export async function createOrUpdateRoomWithUser(
     users = room.users;
     active_users = room.active_users;
     if (users.indexOf(user_id) === -1) {
-      users.push(user_id);
+      throw new Error("User is not authorized to be in the room");
     }
     if (active_users.indexOf(user_id) === -1) {
       active_users.push(user_id);
     }
   }
 
-  await prisma.room.upsert({
+  await prisma.room.update({
     where: {
       room_id: room_id,
     },
-    update: {
+    data: {
       status: "active",
       users: {
         set: users,
@@ -180,14 +180,7 @@ export async function createOrUpdateRoomWithUser(
       active_users: {
         set: active_users,
       },
-    },
-    create: {
-      room_id: room_id,
-      text: "",
-      status: "active",
-      users: [user_id],
-      active_users: [user_id],
-    },
+    }
   });
 }
 

--- a/services/matching-service/src/controllers/matchingController.ts
+++ b/services/matching-service/src/controllers/matchingController.ts
@@ -9,7 +9,7 @@ export const MAX_WAITING_TIME = 60 * 1000; // 60 seconds
 
 export async function handleConnection(socket: Socket) {
   let userId = (socket.handshake.query.username as string) || "";
-  console.log(`User connected: ${socket.id} and username ${userId}`);
+  console.log(`User connected: ${socket.id} and username ${userId}. ${(await io.fetchSockets()).length} users in total.`);
 
   const { count: earlierWaitingCount } = await prisma.waitingUser.deleteMany({
     where: {
@@ -153,6 +153,7 @@ export function handleLooking(
               room_id: newMatch.roomId,
               status: EnumRoomStatus.active,
               text: "",
+              users: [matchingUser.userId, userId],
             },
           });
           await tx.waitingUser.deleteMany({


### PR DESCRIPTION
Often, the frontend makes so many duplicate socket connections to the backend.

Also, the video room display name is currently always set to the user id, which is not human-readable...

And we should not allow any unauthorized user to join a room in collaboration service.

This PR fixes these problems.